### PR TITLE
WebViewコンテンツ下部の高さを増やす

### DIFF
--- a/storkre-child/library/widget.php
+++ b/storkre-child/library/widget.php
@@ -50,6 +50,16 @@ function theme_register_sidebars_child() {
     'before_title' => '<h4 class="widgettitle">',
     'after_title' => '</h4>',
   ));
+
+  register_sidebar(array(
+    'id' => 'addbanner-sp-contentfoot',
+    'name' => __( 'SP：[広告]記事コンテンツ下', 'storktheme' ),
+    'description' => __( '記事コンテンツ下にAdsenseなどの広告を表示します。テキストウィジェットを追加して広告コードを貼り付けて下さい。こちらはスマートフォン用！【推奨サイズ】300×250', 'storktheme' ),
+    'before_widget' => '<div id="%1$s" class="widget %2$s">',
+    'after_widget' => '</div>',
+    'before_title' => '<h4 class="widgettitle"><span>',
+    'after_title' => '</span></h4>',
+  ));
 }
 
 // 人気記事

--- a/storkre-child/sass/partials/app/_single.sass
+++ b/storkre-child/sass/partials/app/_single.sass
@@ -1,0 +1,24 @@
+.app
+  &__single
+    &__container
+      .entry-content
+        padding-bottom: 0
+
+    &__after
+      h4
+        padding: 12px 10px
+
+      .wpp-list
+        li
+          margin: 0 0 10px
+          padding-bottom: 0
+
+        a
+          font-size: 14px
+          font-weight: bold
+          text-decoration: none
+          color: #444
+
+          &:visited
+            text-decoration: none
+            color: #444

--- a/storkre-child/sass/partials/common/_layout.scss
+++ b/storkre-child/sass/partials/common/_layout.scss
@@ -25,6 +25,7 @@
 
 // App Only
 @import 'partials/app/faq';
+@import 'partials/app/single';
 
 .wf-amatic {
   @extend %webfont-amatic;

--- a/storkre-child/single-app.php
+++ b/storkre-child/single-app.php
@@ -5,7 +5,7 @@ $post_class = 'app__single'
 
 <?php get_header('app'); ?>
 <div id="single__container" class="single__container">
-  <div id="content">
+  <div id="content" class="app__single__container">
     <div id="inner-content" class="wrap cf">
       <main id="main" class="m-all t-all d-5of7 cf" role="main">
         <?php while (have_posts()) {
@@ -77,17 +77,27 @@ $post_class = 'app__single'
           </section>
 
           <?php if (is_active_sidebar('addbanner-sp-contentfoot') && is_mobile()) : ?>
-          <div class="ad__sp-content">
-            <?php dynamic_sidebar('addbanner-sp-contentfoot'); ?>
-          </div>
+            <div class="ad__sp-content">
+              <?php dynamic_sidebar('addbanner-sp-contentfoot'); ?>
+            </div>
           <?php endif; ?>
-
-          <?php // Google Recommend ?>
           </article>
+
+          <div class="app__single__after">
+            <div class="widget_text widget widget_custom_html">
+              <h4 class="widgettitle">人気ランキング</h4>
+              <div class="textwidget custom-html-widget">
+                <?php echo do_shortcode('[wpp range="last3days" order_by="views" post_type="event" limit="10" thumbnail_width="140" thumbnail_height="80" stats_views="0"]'); ?>
+              </div>
+            </div>
+
+            <?php get_template_part('gad-related'); ?>
+
+            <?php // TODO 新着一覧もつける ?>
+          </div>
           <?php
-          }
+          } // end while
         ?>
-        <hr class="hr__gradient">
       </main>
     </div>
   </div>

--- a/storkre-child/single-app.php
+++ b/storkre-child/single-app.php
@@ -55,13 +55,6 @@ $post_class = 'app__single'
           <?php endif; ?>
 
           <section class="entry-content cf">
-
-          <?php if (is_active_sidebar('addbanner-pc-titleunder') && !wp_is_mobile()) { ?>
-            <div class="ad__title-under">
-              <?php dynamic_sidebar( 'addbanner-pc-titleunder' ); ?>
-            </div>
-          <?php } ?>
-
           <?php
             // フィルターを通してthe_contentを呼び出す
             $the_content = apply_filters('the_content', get_the_content());
@@ -78,19 +71,14 @@ $post_class = 'app__single'
               <?php get_template_part( 'event-meta-event-single' ); ?>
             </div>
 
-            <?php if ( is_active_sidebar( 'addbanner-pc-contentfoot' ) && !is_mobile() ) : ?>
-              <div class="ad__pc-content">
-                <?php dynamic_sidebar( 'addbanner-pc-contentfoot' ); ?>
-              </div>
-            <?php endif; ?>
             <p class="entry-author vcard author">
               <span class="writer name fn"><?php the_author_meta('nickname'); ?></span>
             </p>
           </section>
 
-          <?php if ( is_active_sidebar( 'addbanner-sp-contentfoot' ) && is_mobile() ) : ?>
+          <?php if (is_active_sidebar('addbanner-sp-contentfoot') && is_mobile()) : ?>
           <div class="ad__sp-content">
-            <?php dynamic_sidebar( 'addbanner-sp-contentfoot' ); ?>
+            <?php dynamic_sidebar('addbanner-sp-contentfoot'); ?>
           </div>
           <?php endif; ?>
 
@@ -99,6 +87,7 @@ $post_class = 'app__single'
           <?php
           }
         ?>
+        <hr class="hr__gradient">
       </main>
     </div>
   </div>


### PR DESCRIPTION
## Why?

現在のアプリ実装はコンテンツ下部までスクロールするとアプリ側でRelated Postsを呼ぶようにしており、コンテンツ量が少ない記事だとすぐスクロールが終わってしまいOverlayしてくるのが気になるため高さを増やした。