### PR TITLE
FLUX広告をトライアルする間はGoogle広告を表示させない

### DIFF
--- a/storkre-child/functions.php
+++ b/storkre-child/functions.php
@@ -73,6 +73,24 @@ add_filter('admin_footer_text', 'remove_footer_admin');
 // <moreads>をADXとアドセンスに置き換える
 // add_filter('the_content', 'adMoreReplace');
 
+// 記事中のGoogleアドセンスを他の広告に差し替えるのに使用
+function is_hide_google_adsense($id) {
+  // flux_show_flag = カスタムフィールド
+  $flux_ad_show_flag =  get_post_meta($id, 'flux_show_flag');
+  // カスタムフィールドでフラグをONにしたら、Googleアドセンスを表示させない
+  $hide_google_adsensse = false;
+
+  if (empty($flux_ad_show_flag)) {
+    $hide_google_adsensse = false;
+  } else if ($flux_ad_show_flag[0] === '1') {
+    $hide_google_adsensse = true;
+  } else if ($flux_ad_show_flag[0] === '0') {
+    $hide_google_adsensse = false;
+  }
+
+  return $hide_google_adsensse;
+}
+
 function get_moreads_tags($device) {
 $moretags = [];
 // AMP - CC_AMP_Article1_Responsive
@@ -333,6 +351,7 @@ $moretags['pc'][] = <<< EOF
 
 EOF;
 
+
 if ($device === 'pc') {
   return $moretags['pc'];
 } else if ($device === 'sp') {
@@ -373,11 +392,17 @@ if (! empty($_GET['amp']) && $_GET['amp'] === '1') {
   // SPだけ実行
 } else if ($is_sp) {
   function replace_sp_moreads($the_content) {
+    global $post;
     $pattern = '/<p><moreads><\/moreads><\/p>/is';
     $serach_moreads = preg_match_all($pattern, $the_content, $moreads_content);
     $moreads_count_inpost = count($moreads_content[0]);
     $moreads = get_moreads_tags('sp');
     $moreads_tag_count = count($moreads);
+
+    // カスタムフィールドがONの場合、moreadsを空にする
+    if (is_hide_google_adsense($post->ID)) {
+      $moreads = array_fill(0, $moreads_tag_count, '');
+    }
 
     if ($moreads_tag_count < $moreads_count_inpost) {
       $diff_count = $moreads_count_inpost - $moreads_tag_count;
@@ -399,11 +424,19 @@ if (! empty($_GET['amp']) && $_GET['amp'] === '1') {
   // PCだけ実行
 } else if ($is_pc) {
   function replace_pc_moreads($the_content) {
+    global $post;
     $pattern = '/<p><moreads><\/moreads><\/p>/is';
     $serach_moreads = preg_match_all($pattern, $the_content, $moreads_content);
     $moreads_count_inpost = count($moreads_content[0]);
     $moreads = get_moreads_tags('pc');
     $moreads_tag_count = count($moreads);
+
+    // カスタムフィールドがONの場合、moreadsを空にする
+    if (is_hide_google_adsense($post->ID)) {
+      $moreads = array_fill(0, $moreads_tag_count, '');
+    }
+
+    print_r($moreads);
 
     if ($moreads_tag_count < $moreads_count_inpost) {
       $diff_count = $moreads_count_inpost - $moreads_tag_count;

--- a/storkre-child/functions.php
+++ b/storkre-child/functions.php
@@ -436,8 +436,6 @@ if (! empty($_GET['amp']) && $_GET['amp'] === '1') {
       $moreads = array_fill(0, $moreads_tag_count, '');
     }
 
-    print_r($moreads);
-
     if ($moreads_tag_count < $moreads_count_inpost) {
       $diff_count = $moreads_count_inpost - $moreads_tag_count;
       $end_tags = end($moreads);

--- a/storkre-child/partials/adx.php
+++ b/storkre-child/partials/adx.php
@@ -1,17 +1,19 @@
-<?php global $is_sp, $is_pc ?>
+<?php global $is_sp, $is_pc, $post ?>
 <?php // Google Adsense ?>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 
+<?php if (is_single() && is_hide_google_adsense($post->ID)) { ?>
+  <script src="https://flux-cdn.com/client/1000300/collabo-cafe_01514.min.js" async></script>
+<?php } ?>
+
 <?php if ($is_sp && is_web()) { ?>
-  <?php if (! is_app()) { // Geniee Tag for Google Ad Manager ?>
-    <script>
-      window.gnshbrequest = window.gnshbrequest || {cmd:[]};
-        gnshbrequest.cmd.push(function(){
-          gnshbrequest.registerPassback("1511018");
-          gnshbrequest.forceInternalRequest();
-      });
-    </script>
-    <script async src="https://cpt.geniee.jp/hb/v1/213660/461/wrapper.min.js"></script>
-    <script src="https://cpt.geniee.jp/hb/v1/213660/461/instbody.min.js"></script>
-  <?php } ?>
+  <script>
+    window.gnshbrequest = window.gnshbrequest || {cmd:[]};
+      gnshbrequest.cmd.push(function(){
+        gnshbrequest.registerPassback("1511018");
+        gnshbrequest.forceInternalRequest();
+    });
+  </script>
+<script async src="https://cpt.geniee.jp/hb/v1/213660/461/wrapper.min.js"></script>
+<script src="https://cpt.geniee.jp/hb/v1/213660/461/instbody.min.js"></script>
 <?php } ?>

--- a/storkre-child/single.php
+++ b/storkre-child/single.php
@@ -62,20 +62,22 @@
     </header>
 
 
-    <?php if ( is_active_sidebar( 'addbanner-sp-titleunder' ) ) : ?>
-      <?php if ( wp_is_mobile() ) : ?>
+    <?php if (is_active_sidebar('addbanner-sp-titleunder')) { ?>
+      <?php if (wp_is_mobile() && ! is_hide_google_adsense($post->ID)) { // NOTE: FLUXタグを読み込む時はGoogleアドセンスを表示しない ?>
         <div class="ad__title-under">
           <?php dynamic_sidebar( 'addbanner-sp-titleunder' ); ?>
         </div>
-      <?php endif; ?>
-    <?php endif; ?>
+      <?php } ?>
+    <?php } ?>
 
     <section class="entry-content cf">
 
-    <?php if (is_active_sidebar('addbanner-pc-titleunder') && !wp_is_mobile()) { ?>
-      <div class="ad__title-under">
-        <?php dynamic_sidebar( 'addbanner-pc-titleunder' ); ?>
-      </div>
+    <?php if (is_active_sidebar('addbanner-pc-titleunder') && ! wp_is_mobile()) { ?>
+      <?php if (! is_hide_google_adsense($post->ID)) { ?>
+        <div class="ad__title-under">
+          <?php dynamic_sidebar( 'addbanner-pc-titleunder' ); ?>
+        </div>
+      <?php } ?>
     <?php } ?>
 
     <?php


### PR DESCRIPTION
## 要件

- FLUX ( https://flux.jp/ )の広告をお試しで表示させたい
- FLUXの広告を表示する記事では、Googleアドセンス、アドマネージャー、アドエクスチェンジを表示させない

## 使い方

- 「FLUGタグを表示する」カスタムフィールドをONにした場合
  - Google関連広告を表示させない
- 「FLUGタグを表示する」カスタムフィールドをOFFにした場合
  - 元々のGoogle広告を表示する

## 関連

- 別件で、ジーニー ( https://geniee.co.jp/ )の新しい全画面広告を1月からお試し中 ( コード修正なし )
- FLUX導入後、トラブルがあった場合、問題の切り分けが少々ややこしい
- やり取り担当 : トラストリッジ ( https://trustridge.jp/ )